### PR TITLE
Add keywordsCaseInsensitive option

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -100,6 +100,7 @@
       error: false,
       value: null,
       getType: null,
+      keywordsCaseInsensitive: false
     }
 
     // Avoid Object.assign(), so we support IE9+
@@ -117,7 +118,7 @@
            : isRegExp(b) ? -1 : isRegExp(a) ? +1 : b.length - a.length
     })
     if (options.keywords) {
-      options.getType = keywordTransform(options.keywords)
+      options.getType = keywordTransform(options.keywords, options.keywordsCaseInsensitive)
     }
     return options
   }
@@ -208,7 +209,7 @@
     return new Lexer(map, start)
   }
 
-  function keywordTransform(map) {
+  function keywordTransform(map, caseInsensitive) {
     var reverseMap = Object.create(null)
     var byLength = Object.create(null)
     var types = Object.getOwnPropertyNames(map)
@@ -217,10 +218,12 @@
       var item = map[tokenType]
       var keywordList = Array.isArray(item) ? item : [item]
       keywordList.forEach(function(keyword) {
-        (byLength[keyword.length] = byLength[keyword.length] || []).push(keyword)
         if (typeof keyword !== 'string') {
           throw new Error("keyword must be string (in keyword '" + tokenType + "')")
         }
+        if(caseInsensitive) keyword = keyword.toUpperCase();
+        (byLength[keyword.length] = byLength[keyword.length] || []).push(keyword)
+        
         reverseMap[keyword] = tokenType
       })
     }
@@ -230,6 +233,7 @@
     function str(x) { return JSON.stringify(x) }
     var source = ''
     source += '(function(value) {\n'
+    if(caseInsensitive) source += 'value = value.toUpperCase(); \n';
     source += 'switch (value.length) {\n'
     for (var length in byLength) {
       var keywords = byLength[length]

--- a/test/test.js
+++ b/test/test.js
@@ -197,6 +197,40 @@ describe('keywords', () => {
     })).toThrow("keyword must be string (in keyword 'kw-class')")
   })
 
+  test('suports case insensitive keywords', () => {
+    let lexer = compile({
+      identifier: {
+        match: /[a-zA-Z]+/,
+        keywordsCaseInsensitive: true,
+        keywords: {
+          'kw-class': 'class',
+          'kw-def': 'def',
+          'kw-if': 'if',
+        },
+      },
+      space: {match: /\s+/, lineBreaks: true},
+    })
+    const input = 'foo def class className FOO Def clAss CLassNaME';
+    lexer.reset(input);
+    expect(Array.from(lexer).map(t => ({ type: t.type, value: t.value }))).toEqual([
+      { type: 'identifier', value: 'foo'},
+      { type: 'space', value: ' '},
+      { type: 'kw-def', value: 'def'},
+      { type: 'space', value: ' '},
+      { type: 'kw-class', value: 'class'},
+      { type: 'space', value: ' '},
+      { type: 'identifier', value: 'className'},
+      { type: 'space', value: ' '},
+      { type: 'identifier', value: 'FOO'},
+      { type: 'space', value: ' '},
+      { type: 'kw-def', value: 'Def'},
+      { type: 'space', value: ' '},
+      { type: 'kw-class', value: 'clAss'},
+      { type: 'space', value: ' '},
+      { type: 'identifier', value: 'CLassNaME'}
+    ])
+  })
+
 })
 
 describe('value transforms', () => {


### PR DESCRIPTION
I added an option to use case insensitive keywords, but by default they are case sensitive, and the fast string lookup function is unaffected. Essentially, when keywordsCaseInsensitive is true, the keywords themselves are converted to upper case when creating the fast string lookup function, and the function converts values it is searching for to upper case before matching.

The option works as follows:

```javascript
   let lexer = compile({
      identifier: {
        match: /[a-zA-Z]+/,
        keywordsCaseInsensitive: true,
        keywords: {
          'kw-class': 'class',
          'kw-def': 'def',
          'kw-if': 'if',
        },
      },
      space: {match: /\s+/, lineBreaks: true},
    })
```