### PR TITLE
Add type transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,13 @@ Moo makes it convenient to define literals.
 
 It'll automatically compile them into regular expressions, escaping them where necessary.
 
-**Keywords** should be written using the `keywords` attribute.
+**Keywords** should be written using the `keywords` transform.
 
 ```js
     moo.compile({
-      IDEN: {match: /[a-zA-Z]+/, keywords: {
+      IDEN: {match: /[a-zA-Z]+/, type: moo.keywords({
         KW: ['while', 'if', 'else', 'moo', 'cows'],
-      }},
+      })},
       SPACE: {match: /\s+/, lineBreaks: true},
     })
 ```
@@ -209,11 +209,11 @@ Keywords can also have **individual types**.
 
 ```js
     let lexer = moo.compile({
-      name: {match: /[a-zA-Z]+/, keywords: {
+      name: {match: /[a-zA-Z]+/, type: moo.keywords({
         'kw-class': 'class',
         'kw-def': 'def',
         'kw-if': 'if',
-      }},
+      })},
       // ...
     })
     lexer.reset('def foo')

--- a/moo.js
+++ b/moo.js
@@ -130,15 +130,6 @@
       }
     }
 
-    // `keywords: obj` is shorthand for `type: moo.keywords(obj)`
-    if (options.keywords) {
-      // Warn if both keywords and type are set
-      if (options.type) {
-        throw new Error("Cannot have both keywords and type (for token '" + type + "')")
-      }
-      options.type = keywordTransform(options.keywords)
-    }
-
     // type transform cannot be a string
     if (typeof options.type === 'string' && type !== options.type) {
       throw new Error("Type transform cannot be a string (type '" + options.type + "' for token '" + type + "')")
@@ -576,9 +567,6 @@
       for (var i = 0; i < groups.length; i++) {
         var group = groups[i]
         if (group.defaultType === tokenType) return true
-        if (group.keywords && hasOwnProperty.call(group.keywords, tokenType)) {
-          return true
-        }
       }
     }
     return false

--- a/moo.js
+++ b/moo.js
@@ -130,6 +130,15 @@
       }
     }
 
+    // `keywords: obj` is shorthand for `type: moo.keywords(obj)`
+    if (options.keywords) {
+      // Warn if both keywords and type are set
+      if (options.type) {
+        throw new Error("Cannot have both keywords and type (for token '" + options.defaultType + "')")
+      }
+      options.type = keywordTransform(options.keywords)
+    }
+
     // convert to array
     var match = options.match
     options.match = Array.isArray(match) ? match : match ? [match] : []
@@ -137,9 +146,6 @@
       return isRegExp(a) && isRegExp(b) ? 0
            : isRegExp(b) ? -1 : isRegExp(a) ? +1 : b.length - a.length
     })
-    if (options.keywords) {
-      options.type = keywordTransform(options.keywords)
-    }
     return options
   }
 

--- a/moo.js
+++ b/moo.js
@@ -93,15 +93,15 @@
         }
         continue
       }
-      if (!obj.name) {
-        throw new Error('Rule has no name: ' + JSON.stringify(obj))
+      if (!obj.type) {
+        throw new Error('Rule has no type: ' + JSON.stringify(obj))
       }
-      result.push(ruleOptions(obj.name, obj))
+      result.push(ruleOptions(obj.type, obj))
     }
     return result
   }
 
-  function ruleOptions(name, obj) {
+  function ruleOptions(type, obj) {
     if (!isObject(obj)) {
       obj = { match: obj }
     }
@@ -111,7 +111,7 @@
 
     // nb. error and fallback imply lineBreaks
     var options = {
-      defaultType: name,
+      defaultType: type,
       lineBreaks: !!obj.error || !!obj.fallback,
       pop: false,
       next: null,
@@ -134,14 +134,14 @@
     if (options.keywords) {
       // Warn if both keywords and type are set
       if (options.type) {
-        throw new Error("Cannot have both keywords and type (for token '" + name + "')")
+        throw new Error("Cannot have both keywords and type (for token '" + type + "')")
       }
       options.type = keywordTransform(options.keywords)
     }
 
     // type transform cannot be a string
-    if (typeof options.type === 'string') {
-      throw new Error("Type transform cannot be a string (type '" + options.type + "' for token '" + name + "')")
+    if (typeof options.type === 'string' && type !== options.type) {
+      throw new Error("Type transform cannot be a string (type '" + options.type + "' for token '" + type + "')")
     }
 
     // convert to array

--- a/moo.js
+++ b/moo.js
@@ -560,16 +560,7 @@
   }
 
   Lexer.prototype.has = function(tokenType) {
-    for (var s in this.states) {
-      var state = this.states[s]
-      if (state.error && state.error.defaultType === tokenType) return true
-      var groups = state.groups
-      for (var i = 0; i < groups.length; i++) {
-        var group = groups[i]
-        if (group.defaultType === tokenType) return true
-      }
-    }
-    return false
+    return true
   }
 
 

--- a/moo.js
+++ b/moo.js
@@ -134,9 +134,14 @@
     if (options.keywords) {
       // Warn if both keywords and type are set
       if (options.type) {
-        throw new Error("Cannot have both keywords and type (for token '" + options.defaultType + "')")
+        throw new Error("Cannot have both keywords and type (for token '" + name + "')")
       }
       options.type = keywordTransform(options.keywords)
+    }
+
+    // type transform cannot be a string
+    if (typeof options.type === 'string') {
+      throw new Error("Type transform cannot be a string (type '" + options.type + "' for token '" + name + "')")
     }
 
     // convert to array

--- a/test/test.js
+++ b/test/test.js
@@ -406,6 +406,14 @@ describe('type transforms', () => {
     })).toThrow("Cannot have both keywords and type (for token 'identifier')")
   })
 
+  test('cannot set type to a string', () => {
+    expect(() => compile({
+      identifier: {
+        type: 'moo',
+      },
+    })).toThrow("Type transform cannot be a string (type 'moo' for token 'identifier')")
+  })
+
 })
 
 describe('value transforms', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -110,10 +110,10 @@ describe('compiler', () => {
 
   test('accepts rules in an array', () => {
     const lexer = compile([
-      { name: 'keyword', match: 'Bob'},
-      { name: 'word', match: /[a-z]+/},
-      { name: 'number', match: /[0-9]+/},
-      { name: 'space', match: / +/},
+      { type: 'keyword', match: 'Bob'},
+      { type: 'word', match: /[a-z]+/},
+      { type: 'number', match: /[0-9]+/},
+      { type: 'space', match: / +/},
     ])
     lexer.reset('Bob ducks are 123 bad')
     expect(lexer.next()).toMatchObject({type: 'keyword', value: 'Bob'})

--- a/test/test.js
+++ b/test/test.js
@@ -561,12 +561,8 @@ describe('Lexer#has', () => {
     expect(basicLexer.has('error')).toBe(true)
   })
 
-  test('returns false for nonexistent junk', () => {
-    expect(basicLexer.has('random')).toBe(false)
-  })
-
-  test('returns false for stuff inherited from Object', () => {
-    expect(basicLexer.has('hasOwnProperty')).toBe(false)
+  test('returns true even for nonexistent junk', () => {
+    expect(basicLexer.has('random')).toBe(true)
   })
 
   const keywordLexer = compile({
@@ -580,9 +576,8 @@ describe('Lexer#has', () => {
     },
   })
 
-  test("doesn't work with keywords", () => {
-    expect(keywordLexer.has('identifier')).toBe(true)
-    expect(keywordLexer.has('kw-class')).toBe(false)
+  test("returns true even for keywords", () => {
+    expect(keywordLexer.has('kw-class')).toBe(true)
   })
 
   // Example from the readme.
@@ -613,20 +608,12 @@ describe('Lexer#has', () => {
     expect(statefulLexer.has('interp')).toEqual(true)
   })
 
-	test('works with error tokens - for first state', () => {
-		expect(statefulLexer.has('mainErr')).toEqual(true)
-	})
-
-	test('works with error tokens - for second state', () => {
-		expect(statefulLexer.has('litErr')).toEqual(true)
-	})
-
-  test('returns false for the state names themselves', () => {
-    expect(statefulLexer.has('main')).toEqual(false)
+  test('works with error tokens - for first state', () => {
+    expect(statefulLexer.has('mainErr')).toEqual(true)
   })
 
-  test('returns false for stuff inherited from Object when using states', () => {
-    expect(statefulLexer.has('toString')).toEqual(false)
+  test('works with error tokens - for second state', () => {
+    expect(statefulLexer.has('litErr')).toEqual(true)
   })
 
 })

--- a/test/test.js
+++ b/test/test.js
@@ -304,10 +304,10 @@ describe('keywords', () => {
     }
 
     check(compile({
-      identifier: {match: /[a-zA-Z]+/, keywords: {keyword: 'class'}},
+      identifier: {match: /[a-zA-Z]+/, type: moo.keywords({keyword: 'class'})},
     }))
     check(compile({
-      identifier: {match: /[a-zA-Z]+/, keywords: {keyword: ['class']}},
+      identifier: {match: /[a-zA-Z]+/, type: moo.keywords({keyword: ['class']})},
     }))
   })
 
@@ -315,11 +315,11 @@ describe('keywords', () => {
     let lexer = compile({
       identifier: {
         match: /[a-zA-Z]+/,
-        keywords: {
+        type: moo.keywords({
           'kw-class': 'class',
           'kw-def': 'def',
           'kw-if': 'if',
-        },
+        }),
       },
       space: {match: /\s+/, lineBreaks: true},
     })
@@ -335,9 +335,9 @@ describe('keywords', () => {
     expect(() => compile({
       identifier: {
         match: /[a-zA-Z]+/,
-        keywords: {
+        type: moo.keywords({
           'kw-class': {foo: 'bar'},
-        },
+        }),
       },
     })).toThrow("keyword must be string (in keyword 'kw-class')")
   })
@@ -395,15 +395,6 @@ describe('type transforms', () => {
     expect(lexer.next()).toMatchObject({ type: 'keyword', value: 'mOo' })
     lexer.reset('cheese')
     expect(lexer.next()).toMatchObject({ type: 'identifier', value: 'cheese'})
-  })
-
-  test('cannot set both type and keywords', () => {
-    expect(() => compile({
-      identifier: {
-        type: () => 'moo',
-        keywords: {foo: 'keyword'},
-      },
-    })).toThrow("Cannot have both keywords and type (for token 'identifier')")
   })
 
   test('cannot set type to a string', () => {
@@ -526,7 +517,7 @@ describe('lexer', () => {
     // TODO: why does toString() return the value?
     const lexer = compile({
       apples: 'a',
-      name: {match: /[a-z]/, keywords: { kw: ['m'] }},
+      name: {match: /[a-z]/, type: moo.keywords({ kw: ['m'] })},
     }).reset('azm')
     expect(String(lexer.next())).toBe('a')
     expect(String(lexer.next())).toBe('z')
@@ -581,17 +572,17 @@ describe('Lexer#has', () => {
   const keywordLexer = compile({
     identifier: {
       match: /[a-zA-Z]+/,
-      keywords: {
+      type: moo.keywords({
         'kw-class': 'class',
         'kw-def': 'def',
         'kw-if': 'if',
-      },
+      }),
     },
   })
 
-  test('works with keywords', () => {
+  test("doesn't work with keywords", () => {
     expect(keywordLexer.has('identifier')).toBe(true)
-    expect(keywordLexer.has('kw-class')).toBe(true)
+    expect(keywordLexer.has('kw-class')).toBe(false)
   })
 
   // Example from the readme.

--- a/test/test.js
+++ b/test/test.js
@@ -405,6 +405,23 @@ describe('type transforms', () => {
     })).toThrow("Type transform cannot be a string (type 'moo' for token 'identifier')")
   })
 
+  test('can be used in an array', () => {
+    const lexer = compile([
+      { type: (name) => 'word-' + name, match: /[a-z]+/},
+      { type: 'space', match: / +/},
+    ])
+    lexer.reset('foo ')
+    expect(lexer.next()).toMatchObject({type: 'word-foo', value: 'foo'})
+    expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
+  })
+
+  test('may result in questionable errors', () => {
+    const myTransform = function() {}
+    expect(() => compile([
+      { type: myTransform, next: 'moo'},
+    ])).toThrow("State-switching options are not allowed in stateless lexers (for token 'function () {}')")
+  })
+
 })
 
 describe('value transforms', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -397,6 +397,15 @@ describe('type transforms', () => {
     expect(lexer.next()).toMatchObject({ type: 'identifier', value: 'cheese'})
   })
 
+  test('cannot set both type and keywords', () => {
+    expect(() => compile({
+      identifier: {
+        type: () => 'moo',
+        keywords: {foo: 'keyword'},
+      },
+    })).toThrow("Cannot have both keywords and type (for token 'identifier')")
+  })
+
 })
 
 describe('value transforms', () => {

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -2,32 +2,32 @@
 const moo = require('../moo')
 
 let toshLexer = moo.compile([
-  {name: 'symbol',  match: Array.from('-%#+*/=^,?')},  // single character
-  {name: 'WS',      match: /[ \t]+/},
-  {name: 'ellips',  match: /\.{3}/},
-  {name: 'comment', match: /\/{2}.*$/},
-  {name: 'false',   match: /\<\>/},
-  {name: 'zero',    match: /\(\)/},
-  {name: 'empty',   match: /_(?: |$)/},
-  {name: 'number',  match: /[0-9]+(?:\.[0-9]+)?e-?[0-9]+/}, // 123[.123]e[-]123
-  {name: 'number',  match: /(?:0|[1-9][0-9]*)?\.[0-9]+/},   // [123].123
-  {name: 'number',  match: /(?:0|[1-9][0-9]*)\.[0-9]*/},    // 123.[123]
-  {name: 'number',  match: /0|[1-9][0-9]*/},              // 123
-  {name: 'color',   match: /#(?:[A-Fa-f0-9]{3}){2}/},
-  {name: 'string',  match: /"(?:\\["\\]|[^\n"\\])*"/}, // strings are backslash-escaped
-  {name: 'string',  match: /'(?:\\['\\]|[^\n'\\])*'/},
-  {name: 'lparen',  match: /\(/},
-  {name: 'rparen',  match: /\)/},
-  {name: 'langle',  match: /\</},
-  {name: 'rangle',  match: /\>/},
-  {name: 'lsquare', match: /\[/},
-  {name: 'rsquare', match: /\]/},
-  {name: 'cloud',   match: /[☁]/},
-  {name: 'input',   match: /%[a-z](?:\.[a-zA-Z]+)?/},
-  {name: 'symbol',  match: /[_A-Za-z][-_A-Za-z0-9:',.]*/}, // word, as in a block
-  {name: 'iden',    match: /[^\n \t"'()<>=*\/+-]+/},     // user-defined names
-  {name: 'NL',      match: /\n/, lineBreaks: true },
-  {name: 'ERROR',   error: true},
+  {type: 'symbol',  match: Array.from('-%#+*/=^,?')},  // single character
+  {type: 'WS',      match: /[ \t]+/},
+  {type: 'ellips',  match: /\.{3}/},
+  {type: 'comment', match: /\/{2}.*$/},
+  {type: 'false',   match: /\<\>/},
+  {type: 'zero',    match: /\(\)/},
+  {type: 'empty',   match: /_(?: |$)/},
+  {type: 'number',  match: /[0-9]+(?:\.[0-9]+)?e-?[0-9]+/}, // 123[.123]e[-]123
+  {type: 'number',  match: /(?:0|[1-9][0-9]*)?\.[0-9]+/},   // [123].123
+  {type: 'number',  match: /(?:0|[1-9][0-9]*)\.[0-9]*/},    // 123.[123]
+  {type: 'number',  match: /0|[1-9][0-9]*/},              // 123
+  {type: 'color',   match: /#(?:[A-Fa-f0-9]{3}){2}/},
+  {type: 'string',  match: /"(?:\\["\\]|[^\n"\\])*"/}, // strings are backslash-escaped
+  {type: 'string',  match: /'(?:\\['\\]|[^\n'\\])*'/},
+  {type: 'lparen',  match: /\(/},
+  {type: 'rparen',  match: /\)/},
+  {type: 'langle',  match: /\</},
+  {type: 'rangle',  match: /\>/},
+  {type: 'lsquare', match: /\[/},
+  {type: 'rsquare', match: /\]/},
+  {type: 'cloud',   match: /[☁]/},
+  {type: 'input',   match: /%[a-z](?:\.[a-zA-Z]+)?/},
+  {type: 'symbol',  match: /[_A-Za-z][-_A-Za-z0-9:',.]*/}, // word, as in a block
+  {type: 'iden',    match: /[^\n \t"'()<>=*\/+-]+/},     // user-defined type
+  {type: 'NL',      match: /\n/, lineBreaks: true },
+  {type: 'ERROR',   error: true},
 ])
 
 function tokenize(source) {


### PR DESCRIPTION
We recently added a [`value` transform](https://github.com/no-context/moo#transform).

This PR:

* Adds a `type` transform.
* Exposes `moo.keywords()`.
* Removes `Lexer#has()`.

The existing **value** transform takes the `text` and returns the `value`. By default, the text is used unchanged.

The new **type** transform takes the `text` and returns the `type`. By default, the type of the rule is used (e.g. `identifier`).

## Example: case-insensitive keywords

This is my preferred solution for #67 / #78. 

For example, you can create a customised version of `moo.keywords` which matches case-insensitively:

```js
const caseInsensitiveKeywords = map => {
  const transform = moo.keywords(map)
  return text => transform(text.toLowerCase())
}

let lexer = compile({
  identifier: {
    match: /[a-zA-Z]+/,
    type: caseInsensitiveKeywords({
      keyword: ['class', 'def'],
    }),
  },
})
```

## Lexer#has()

This unfortunately makes it impossible to write a `Lexer#has` function, since we can't infer what token names might be returned by this custom function.

This will make Moo incompatible with the current version of Nearley: we introduced `has()` so that we could tell whether `%foo` refers to a custom token matcher such as `foo = { test: x => Number.isInteger(x) }`, or a lexer token. But custom token matchers will likely be removed going forward, so `has()` will have no use.