### PR TITLE
Fix reUnion() for empty regex lists

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -28,6 +28,7 @@
     return '(' + s + ')'
   }
   function reUnion(regexps) {
+    if (!regexps.length) return '(?!)'
     var source =  regexps.map(function(s) {
       return "(?:" + s + ")"
     }).join('|')

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,14 @@ describe('compiler', () => {
     const lex2 = compile({err: moo.error})
     lex2.reset('nope!')
     expect(lex2.next()).toMatchObject({type: 'err', text: 'nope!'})
+
+    const lex3 = moo.states({main: {}})
+    lex3.reset('nope!')
+    expect(() => lex3.next()).toThrow('invalid syntax')
+
+    const lex4 = moo.states({main: {err: moo.error}})
+    lex4.reset('nope!')
+    expect(lex4.next()).toMatchObject({type: 'err', text: 'nope!'})
   })
 
   test("warns for /g, /y, /i, /m", () => {

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,15 @@ function lexAll(lexer) {return Array.from(lexer)}
 
 describe('compiler', () => {
 
-  // TODO handles empty rule set
+  test('handles empty rule set', () => {
+    const lex = compile({})
+    lex.reset('nope!')
+    expect(() => lex.next()).toThrow('invalid syntax')
+
+    const lex2 = compile({err: moo.error})
+    lex2.reset('nope!')
+    expect(lex2.next()).toMatchObject({type: 'err', text: 'nope!'})
+  })
 
   test("warns for /g, /y, /i, /m", () => {
     expect(() => compile({ word: /foo/ })).not.toThrow()


### PR DESCRIPTION
Return `(?!)`, which never matches anything (as mentioned in #91).