### PR TITLE
Proposal: default token types

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -104,6 +104,7 @@
       default: false,
       value: null,
       getType: null,
+      shouldThrow: false,
     }
 
     // Avoid Object.assign(), so we support IE9+
@@ -126,6 +127,7 @@
     return options
   }
 
+  var defaultErrorRule = ruleOptions('error', {lineBreaks: true, shouldThrow: true})
   function compileRules(rules, hasStates) {
     rules = Array.isArray(rules) ? arrayToRules(rules) : objectToRules(rules)
 
@@ -178,7 +180,7 @@
     var flags = hasSticky && !defaultRule ? 'ym' : 'gm'
     var combined = new RegExp(reUnion(parts) + suffix, flags)
 
-    return {regexp: combined, groups: groups, error: errorRule}
+    return {regexp: combined, groups: groups, error: errorRule || defaultErrorRule}
   }
 
   function compile(rules) {
@@ -285,7 +287,7 @@
     this.state = state
     var info = this.states[state]
     this.groups = info.groups
-    this.error = info.error || {lineBreaks: true, shouldThrow: true}
+    this.error = info.error
     this.re = info.regexp
   }
 

--- a/moo.js
+++ b/moo.js
@@ -139,7 +139,7 @@
 
       if (options.error || options.default) {
         if (errorRule) {
-          throw new Error((!options.default === !errorRule.default ? "Multiple " + (options.default ? "default" : "error") + " rules not allowed" : "default and error are mutually exclusive") + ": (for token '" + options.tokenType + "')")
+          throw new Error((!options.default === !errorRule.default ? "Multiple " + (options.default ? "default" : "error") + " rules not allowed" : "default and error are mutually exclusive") + " (for token '" + options.tokenType + "')")
         }
         errorRule = options
       }

--- a/moo.js
+++ b/moo.js
@@ -266,7 +266,7 @@
     this.index = 0
     this.line = info ? info.line : 1
     this.col = info ? info.col : 1
-    this.queued = info ? info.queued : null
+    this.queuedToken = info ? info.queuedToken : null
     this.queuedThrow = info ? info.queuedThrow : null
     this.setState(info ? info.state : this.startState)
     return this
@@ -277,7 +277,7 @@
       line: this.line,
       col: this.col,
       state: this.state,
-      queued: this.queued,
+      queuedToken: this.queuedToken,
       queuedThrow: this.queuedThrow,
     }
   }
@@ -330,14 +330,14 @@
   }
 
   Lexer.prototype.next = function() {
-    if (this.queued) {
-      var queued = this.queued, queuedThrow = this.queuedThrow
-      this.queued = null
+    if (this.queuedToken) {
+      var queuedToken = this.queuedToken, queuedThrow = this.queuedThrow
+      this.queuedToken = null
       this.queuedThrow = false
       if (queuedThrow) {
-        throw new Error(this.formatError(queued, "invalid syntax"))
+        throw new Error(this.formatError(queuedToken, "invalid syntax"))
       }
-      return queued
+      return queuedToken
     }
     var re = this.re
     var buffer = this.buffer
@@ -367,7 +367,7 @@
 
     // throw, if no rule with {error: true}
     if (fallbackToken) {
-      this.queued = token
+      this.queuedToken = token
       this.queuedThrow = group.shouldThrow
     } else if (group.shouldThrow) {
       throw new Error(this.formatError(token, "invalid syntax"))

--- a/moo.js
+++ b/moo.js
@@ -329,10 +329,10 @@
 
   Lexer.prototype.next = function() {
     if (this.queued) {
-      var queued = this.queued
+      var queued = this.queued, queuedThrow = this.queuedThrow
       this.queued = null
       this.queuedThrow = false
-      if (this.queuedThrow) {
+      if (queuedThrow) {
         throw new Error(this.formatError(queued, "invalid syntax"))
       }
       return queued

--- a/test/test.js
+++ b/test/test.js
@@ -181,12 +181,12 @@ describe('compiles literals', () => {
 
 })
 
-describe('default tokens', () => {
+describe('fallback tokens', () => {
 
   test('work', () => {
     const lexer = moo.compile({
       op: /[._]/,
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('.this_that.')
     expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
@@ -199,7 +199,7 @@ describe('default tokens', () => {
   test(`work if there are characters before the first token`, () => {
     const lexer = compile({
       op: /[._]/,
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('.stuff')
     expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
@@ -209,7 +209,7 @@ describe('default tokens', () => {
   test(`work if there are characters after the last token`, () => {
     const lexer = compile({
       op: /[._]/,
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('stuff.')
     expect(lexer.next()).toMatchObject({type: 'text', value: 'stuff'})
@@ -221,7 +221,7 @@ describe('default tokens', () => {
       main: {
         op: /[._]/,
         switch: {match: '|', next: 'other'},
-        text: moo.default,
+        text: moo.fallback,
       },
       other: {
         op: /[+-]/,
@@ -243,7 +243,7 @@ describe('default tokens', () => {
   test(`are never empty`, () => {
     const lexer = moo.compile({
       op: /[._]/,
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('.._._')
     expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
@@ -256,7 +256,7 @@ describe('default tokens', () => {
   test(`report token positions correctly`, () => {
     const lexer = moo.compile({
       op: /[._]/,
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('.this_th\nat.')
     expect(lexer.next()).toMatchObject({value: '.', offset: 0})
@@ -269,7 +269,7 @@ describe('default tokens', () => {
   test(`report token line numbers correctly`, () => {
     const lexer = moo.compile({
       str: {lineBreaks: true, match: /"[^]+?"/},
-      bare: moo.default,
+      bare: moo.fallback,
     })
     lexer.reset('a\nb"some\nthing" else\ngoes\nhere\n\n"\nand here"\n')
     expect(lexer.next()).toMatchObject({value: 'a\nb', line: 1, col: 1})
@@ -282,7 +282,7 @@ describe('default tokens', () => {
   test("don't throw token errors until next() is called again", () => {
     const lexer = moo.compile({
       op: {match: /[._]/, shouldThrow: true},
-      text: moo.default,
+      text: moo.fallback,
     })
     lexer.reset('stuff.')
     expect(lexer.next()).toMatchObject({type: 'text', value: 'stuff'})

--- a/test/test.js
+++ b/test/test.js
@@ -752,7 +752,7 @@ describe('errors', () => {
     expect(() => compile({
       myError: moo.error,
       myError2: moo.error,
-    })).toThrow("Multiple error rules not allowed: (for token 'myError2')")
+    })).toThrow("Multiple error rules not allowed (for token 'myError2')")
   })
 
   test('may also match patterns', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -181,6 +181,116 @@ describe('compiles literals', () => {
 
 })
 
+describe('default tokens', () => {
+
+  test('work', () => {
+    const lexer = moo.compile({
+      op: /[._]/,
+      text: moo.default,
+    })
+    lexer.reset('.this_that.')
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'this'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '_'})
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'that'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+  })
+
+  test(`work if there are characters before the first token`, () => {
+    const lexer = compile({
+      op: /[._]/,
+      text: moo.default,
+    })
+    lexer.reset('.stuff')
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'stuff'})
+  })
+
+  test(`work if there are characters after the last token`, () => {
+    const lexer = compile({
+      op: /[._]/,
+      text: moo.default,
+    })
+    lexer.reset('stuff.')
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'stuff'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+  })
+
+  test('work on stateful lexers', () => {
+    const lexer = moo.states({
+      main: {
+        op: /[._]/,
+        switch: {match: '|', next: 'other'},
+        text: moo.default,
+      },
+      other: {
+        op: /[+-]/,
+      },
+    })
+    lexer.reset('foo.bar_baz|++-!')
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'foo'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'bar'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '_'})
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'baz'})
+    expect(lexer.next()).toMatchObject({type: 'switch', value: '|'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '+'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '+'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '-'})
+    expect(() => lexer.next()).toThrow('invalid syntax')
+  })
+
+  test(`are never empty`, () => {
+    const lexer = moo.compile({
+      op: /[._]/,
+      text: moo.default,
+    })
+    lexer.reset('.._._')
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '_'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '.'})
+    expect(lexer.next()).toMatchObject({type: 'op', value: '_'})
+  })
+
+  test(`report token positions correctly`, () => {
+    const lexer = moo.compile({
+      op: /[._]/,
+      text: moo.default,
+    })
+    lexer.reset('.this_th\nat.')
+    expect(lexer.next()).toMatchObject({value: '.', offset: 0})
+    expect(lexer.next()).toMatchObject({value: 'this', offset: 1})
+    expect(lexer.next()).toMatchObject({value: '_', offset: 5})
+    expect(lexer.next()).toMatchObject({value: 'th\nat', offset: 6})
+    expect(lexer.next()).toMatchObject({value: '.', offset: 11})
+  })
+
+  test(`report token line numbers correctly`, () => {
+    const lexer = moo.compile({
+      str: {lineBreaks: true, match: /"[^]+?"/},
+      bare: moo.default,
+    })
+    lexer.reset('a\nb"some\nthing" else\ngoes\nhere\n\n"\nand here"\n')
+    expect(lexer.next()).toMatchObject({value: 'a\nb', line: 1, col: 1})
+    expect(lexer.next()).toMatchObject({value: '"some\nthing"', line: 2, col: 2})
+    expect(lexer.next()).toMatchObject({value: ' else\ngoes\nhere\n\n', line: 3, col: 7})
+    expect(lexer.next()).toMatchObject({value: '"\nand here"', line: 7, col: 1})
+    expect(lexer.next()).toMatchObject({value: '\n', line: 8, col: 10})
+  })
+
+  test("don't throw token errors until next() is called again", () => {
+    const lexer = moo.compile({
+      op: {match: /[._]/, shouldThrow: true},
+      text: moo.default,
+    })
+    lexer.reset('stuff.')
+    expect(lexer.next()).toMatchObject({type: 'text', value: 'stuff'})
+    expect(() => lexer.next()).toThrow('invalid syntax')
+  })
+
+})
+
 describe('keywords', () => {
 
   test('supports explicit keywords', () => {


### PR DESCRIPTION
Upon further consideration, #88 seems like a good idea. Markdown(ish) syntaxes are the obvious motivating example: arbitrary text with certain embedded sequences have special meanings, and incomplete special sequences should be passed through verbatim.

```js
const lexer = moo.compile({
  para: {lineBreaks: true, match: /(?:\r?\n|\r){2,}/},
  issu: {match: /#\d+/, value: s => s.slice(1)},
  lstr: /\*\*(?=\S)|__(?=\S)/,
  rstr: /\*\*(?=\s|$)|__(?=\s|$)/,
  escp: {match: /\\./, value: s => s.slice(1)},
  text: moo.default,
})

lexer.reset(`
Upon **further consideration,** #88 seems like a good idea.

Markdown(ish) syntaxes are the obvious motivating example…
`.trim())

console.log([...lexer]) /*
[ { type: 'text', value: 'Upon ' },
  { type: 'lstr', value: '**' },
  { type: 'text', value: 'further consideration,' },
  { type: 'rstr', value: '**' },
  { type: 'text', value: ' ' },
  { type: 'issu', value: '88' },
  { type: 'text', value: ' seems like a good idea.' },
  { type: 'para', value: '\n\n' },
  { type: 'text', value: 'Markdown(ish) syntaxes are the obvious motivating example…' } ]
*/
```

@tjvr Feel free to bikeshed the name. (`fill` might be better?)