### PR TITLE
Factor out Matcher

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -260,6 +260,7 @@
       throw new Error("pop must be 1 (in token '" + g.defaultType + "' of state '" + name + "')")
     }
   }
+
   function compileStates(states, start) {
     var all = states.$all ? toRules(states.$all) : []
     delete states.$all
@@ -509,16 +510,14 @@
       }
     }
 
-    var token = {
-      type: (typeof group.type === 'function' && group.type(text)) || group.defaultType,
-      value: typeof group.value === 'function' ? group.value(text) : text,
-      text: text,
-      toString: tokenToString,
-      offset: offset,
-      lineBreaks: lineBreaks,
-      line: this.line,
-      col: this.col,
-    }
+    var token = new Token
+    token.type = (typeof group.type === 'function' && group.type(text)) || group.defaultType
+    token.value = typeof group.value === 'function' ? group.value(text) : text
+    token.text = text
+    token.offset = offset
+    token.lineBreaks = lineBreaks
+    token.line = this.line
+    token.col = this.col
     // nb. adding more props to token object will make V8 sad!
 
     var size = text.length
@@ -569,6 +568,13 @@
 
   Lexer.prototype.has = function(tokenType) {
     return true
+  }
+
+
+  function Token() {}
+
+  Token.prototype.toString = function() {
+    return this.text
   }
 
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -17,15 +17,15 @@ function randomChoice(array) {
 const chevrotain = require('chevrotain')
 function chevrotainFromMoo(lexer) {
   const tokens = []
-  var keys = Object.keys(lexer.fast)
+  var keys = Object.keys(lexer.matcher.fast)
   for (var i=0; i<keys.length; i++) {
     var charCode = keys[i]
     var word = String.fromCharCode(charCode)
     var pat = new RegExp(reEscape(word))
-    var group = lexer.fast[charCode]
+    var group = lexer.matcher.fast[charCode]
     tokens.push(chevrotain.createToken({name: group.tokenType, pattern: pat}))
   }
-  lexer.groups.forEach(group => {
+  lexer.matcher.groups.forEach(group => {
     var options = group.match.map(pat => typeof pat === 'string' ? reEscape(pat) : pat.source)
     var pat = new RegExp(options.join('|'))
     tokens.push(chevrotain.createToken({name: group.tokenType, pattern: pat}))

--- a/test/test.js
+++ b/test/test.js
@@ -102,7 +102,6 @@ describe('compiler', () => {
         'lol',
       ],
     })
-    expect(lexer.groups.length).toBe(3)
     expect(lexer.reset('string').next()).toMatchObject({type: 'op', value: 'string'})
     expect(lexer.reset('regexp').next()).toMatchObject({type: 'op', value: 'regexp'})
     expect(lexer.reset('something').next()).toMatchObject({type: 'op', value: 'something'})
@@ -155,7 +154,8 @@ describe('compiles literals', () => {
     let lexer = moo.compile({
       tok: [/t[ok]+/, /\w/, 'foo', 'token']
     })
-    expect(lexer.re.source.replace(/[(?:)]/g, '').replace(/\|$/, ''))
+    const re = lexer.matcher.regexp
+    expect(re.source.replace(/[(?:)]/g, '').replace(/\|$/, ''))
     .toMatch('token|foo|t[ok]+|\\w')
   })
 
@@ -296,7 +296,7 @@ describe('fallback tokens', () => {
     })
     lexer.reset('foo.bar')
     expect(Array.from(lexer).map(x => x.value)).toEqual(['foo', '.', 'bar'])
-    expect(lexer.fast).toEqual({})
+    expect(lexer.matcher.fast).toEqual({})
   })
 
 })


### PR DESCRIPTION
* Factor out a `Matcher` class, that contains all the matching logic. The `Lexer` knows how to turn a Match into a token, and manage states etc.
* Use a `Token` class, instead of plain objects.
