### PR TITLE
formatError for undefined tokens

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -545,22 +545,20 @@
   }
 
   Lexer.prototype.formatError = function(token, message) {
-    // An undefined token indicates EOF
     if (token == null) {
+      // An undefined token indicates EOF
+      var index = this.index
+      var value = this.buffer.slice(index)
+      var eol = value.indexOf('\n')
+      if (eol === -1) eol = value.length
       var token = {
-        type: undefined,
-        value: "",
-        text: "",
-        toString: tokenToString,
-        offset: this.buffer.length,
-        lineBreaks: 0,
         line: this.line,
         col: this.col,
       }
+    } else {
+      var index = token.offset
+      var eol = token.lineBreaks ? token.text.indexOf('\n') : token.text.length
     }
-    var value = token.text
-    var index = token.offset
-    var eol = token.lineBreaks ? value.indexOf('\n') : value.length
     var start = Math.max(0, index - token.col + 1)
     var firstLine = this.buffer.substring(start, index + eol)
     message += " at line " + token.line + " col " + token.col + ":\n\n"

--- a/moo.js
+++ b/moo.js
@@ -545,6 +545,16 @@
   }
 
   Lexer.prototype.formatError = function(token, message) {
+    // An undefined token indicates EOF
+    if (token == null) {
+      token = {
+        text: "",
+        offset: this.buffer.length,
+        lineBreaks: false,
+        col: this.col,
+        line: this.line,
+      }
+    }
     var value = token.text
     var index = token.offset
     var eol = token.lineBreaks ? value.indexOf('\n') : value.length

--- a/moo.js
+++ b/moo.js
@@ -547,20 +547,18 @@
   Lexer.prototype.formatError = function(token, message) {
     if (token == null) {
       // An undefined token indicates EOF
-      var index = this.index
-      var value = this.buffer.slice(index)
-      var eol = value.indexOf('\n')
-      if (eol === -1) eol = value.length
+      var text = this.buffer.slice(this.index)
       var token = {
+        text: text,
+        offset: this.index,
+        lineBreaks: text.indexOf('\n') === -1 ? 0 : 1,
         line: this.line,
         col: this.col,
       }
-    } else {
-      var index = token.offset
-      var eol = token.lineBreaks ? token.text.indexOf('\n') : token.text.length
     }
-    var start = Math.max(0, index - token.col + 1)
-    var firstLine = this.buffer.substring(start, index + eol)
+    var start = Math.max(0, token.offset - token.col + 1)
+    var eol = token.lineBreaks ? token.text.indexOf('\n') : token.text.length
+    var firstLine = this.buffer.substring(start, token.offset + eol)
     message += " at line " + token.line + " col " + token.col + ":\n\n"
     message += "  " + firstLine + "\n"
     message += "  " + Array(token.col).join(" ") + "^"

--- a/moo.js
+++ b/moo.js
@@ -544,23 +544,19 @@
     }
   }
 
-  Lexer.prototype.makeEOF = function(type) {
-    return {
-      type: type,
-      value: "",
-      text: "",
-      toString: tokenToString,
-      offset: this.buffer.length,
-      lineBreaks: 0,
-      line: this.line,
-      col: this.col,
-    }
-  }
-
   Lexer.prototype.formatError = function(token, message) {
     // An undefined token indicates EOF
     if (token == null) {
-      var token = this.makeEOF()
+      var token = {
+        type: undefined,
+        value: "",
+        text: "",
+        toString: tokenToString,
+        offset: this.buffer.length,
+        lineBreaks: 0,
+        line: this.line,
+        col: this.col,
+      }
     }
     var value = token.text
     var index = token.offset

--- a/moo.js
+++ b/moo.js
@@ -544,16 +544,23 @@
     }
   }
 
+  Lexer.prototype.makeEOF = function(type) {
+    return {
+      type: type,
+      value: "",
+      text: "",
+      toString: tokenToString,
+      offset: this.buffer.length,
+      lineBreaks: 0,
+      line: this.line,
+      col: this.col,
+    }
+  }
+
   Lexer.prototype.formatError = function(token, message) {
     // An undefined token indicates EOF
     if (token == null) {
-      token = {
-        text: "",
-        offset: this.buffer.length,
-        lineBreaks: false,
-        col: this.col,
-        line: this.line,
-      }
+      var token = this.makeEOF()
     }
     var value = token.text
     var index = token.offset

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moo",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1748,12 +1748,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1768,17 +1770,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1895,7 +1900,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1907,6 +1913,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1921,6 +1928,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1928,12 +1936,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1952,6 +1962,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2032,7 +2043,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2044,6 +2056,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2165,6 +2178,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -946,6 +946,26 @@ describe('errors', () => {
     )
   })
 
+  test('can make EOF token', () => {
+    let lexer = compile({
+      ws: {match: /\s/, lineBreaks: true},
+      word: /[a-z]+/,
+    })
+    lexer.reset('abc\ndef quxx')
+    expect(Array.from(lexer).length).toBe(5)
+    const tok = lexer.makeEOF("eof")
+    expect(tok).toMatchObject({
+      type: "eof",
+      value: "",
+      text: "",
+      offset: 12,
+      lineBreaks: 0,
+      line: 2,
+      col: 9,
+    })
+    expect(lexer.makeEOF("eof").toString()).toBe("")
+  })
+
   test('seek to end of buffer when thrown', () => {
     let lexer = compile({
       digits: /[0-9]+/,

--- a/test/test.js
+++ b/test/test.js
@@ -930,7 +930,7 @@ describe('errors', () => {
     )
   })
 
-  test('can format EOF', () => {
+  test('can format null at EOF', () => {
     let lexer = compile({
       ws: {match: /\s/, lineBreaks: true},
       word: /[a-z]+/,
@@ -945,6 +945,24 @@ describe('errors', () => {
       "          ^"
     )
   })
+
+  test('can format null even not at EOF', () => {
+    let lexer = compile({
+      ws: {match: /\s/, lineBreaks: true},
+      word: /[a-z]+/,
+    })
+    lexer.reset('abc\ndef quxx\nbar')
+    lexer.next()
+    lexer.next()
+    expect(lexer.line).toBe(2)
+    expect(lexer.col).toBe(1)
+    expect(lexer.formatError(undefined, "oh no!")).toBe(
+      "oh no! at line 2 col 1:\n\n" +
+      "  def quxx\n" +
+      "  ^"
+    )
+  })
+
 
   test('seek to end of buffer when thrown', () => {
     let lexer = compile({

--- a/test/test.js
+++ b/test/test.js
@@ -946,26 +946,6 @@ describe('errors', () => {
     )
   })
 
-  test('can make EOF token', () => {
-    let lexer = compile({
-      ws: {match: /\s/, lineBreaks: true},
-      word: /[a-z]+/,
-    })
-    lexer.reset('abc\ndef quxx')
-    expect(Array.from(lexer).length).toBe(5)
-    const tok = lexer.makeEOF("eof")
-    expect(tok).toMatchObject({
-      type: "eof",
-      value: "",
-      text: "",
-      offset: 12,
-      lineBreaks: 0,
-      line: 2,
-      col: 9,
-    })
-    expect(lexer.makeEOF("eof").toString()).toBe("")
-  })
-
   test('seek to end of buffer when thrown', () => {
     let lexer = compile({
       digits: /[0-9]+/,

--- a/test/test.js
+++ b/test/test.js
@@ -930,6 +930,22 @@ describe('errors', () => {
     )
   })
 
+  test('can format EOF', () => {
+    let lexer = compile({
+      ws: {match: /\s/, lineBreaks: true},
+      word: /[a-z]+/,
+    })
+    lexer.reset('abc\ndef quxx')
+    expect(Array.from(lexer).length).toBe(5)
+    expect(lexer.line).toBe(2)
+    expect(lexer.col).toBe(9)
+    expect(lexer.formatError(undefined, "EOF!")).toBe(
+      "EOF! at line 2 col 9:\n\n" +
+      "  def quxx\n" +
+      "          ^"
+    )
+  })
+
   test('seek to end of buffer when thrown', () => {
     let lexer = compile({
       digits: /[0-9]+/,


### PR DESCRIPTION
It's fairly natural to write code of the form:

```js
  while (tok = lexer.next()) {
    try {
      parser.eat(tok)
    } catch (err) {
      throw new Error(lexer.formatError(tok, "Syntax error"))
    }
  }

  try {
    var program = parser.result()
  } catch (err) {
    throw new Error(lexer.formatError(tok, "Unexpected EOF")) // Not allowed!
  }
  return program
```

The second `formatError` call is not valid, because `tok` will be `undefined` here. Moo uses `undefined` to indicate that there are no more tokens, i.e. we've reached the end of the buffer.

There's no way to get Moo to format an error at the end of the file, after the last token, without manually constructing an EOF token. I propose letting `formatError` accept `undefined`, and silently interpret it as an EOF token.

Alternatively, we could introduce a `lexer.makeEOF()` method which returns this end-of-file token directly.