### PR TITLE
Fix unicode checks for fallbacks

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -220,6 +220,10 @@
         if (unicodeFlag === null) {
           unicodeFlag = obj.unicode
         } else if (unicodeFlag !== obj.unicode) {
+          if (options.fallback === true) {
+            obj.unicode = true
+            continue
+          }
           throw new Error("If one rule is /u then all must be")
         }
       }


### PR DESCRIPTION
There is no way to provide a unicode fallback pattern currently.

Error: If one rule is /u then all must be