### PR TITLE
Correct states example to use `pop: 1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ For example, to tokenize JS-style string interpolation such as `a${{c: d}}e`, yo
         strstart: {match: '`', push: 'lit'},
         ident:    /\w+/,
         lbrace:   {match: '{', push: 'main'},
-        rbrace:   {match: '}', pop: true},
+        rbrace:   {match: '}', pop: 1},
         colon:    ':',
         space:    {match: /\s+/, lineBreaks: true},
       },
       lit: {
         interp:   {match: '${', push: 'main'},
         escape:   /\\./,
-        strend:   {match: '`', pop: true},
+        strend:   {match: '`', pop: 1},
         const:    {match: /(?:[^$`]|\$(?!\{))+/, lineBreaks: true},
       },
     })


### PR DESCRIPTION
The documentation description just before the example states:

> * **`pop: 1`** removes one state from the top of the stack, and moves to that state. (Only `1` is supported.)

Also the typescript types agree it should be `1` not `true`.