### PR TITLE
Display context and mark out error tokens

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -905,8 +905,9 @@ describe('errors', () => {
     expect(lexer.next()).toMatchObject({value: '456'})
     expect(() => lexer.next()).toThrow(
       "invalid syntax at line 2 col 4:\n\n" +
-      "  456baa\n" +
-      "     ^"
+      "     1\t123\n" +
+      "     2\t456baa\n" +
+      "      \t   ~~~\n"
     )
   })
 
@@ -921,8 +922,12 @@ describe('errors', () => {
     expect(tok).toMatchObject({type: 'error', value: ' 12\n345\n6', lineBreaks: 2})
     expect(lexer.formatError(tok, "numbers!")).toBe(
       "numbers! at line 3 col 2:\n\n" +
-      "  g 12\n" +
-      "   ^"
+      "     1\tabc\n" +
+      "     2\tdef\n" +
+      "     3\tg 12\n" +
+      "     4\t345\n" +
+      "     5\t6\n" +
+      "      \t~\n"
     )
   })
 
@@ -937,8 +942,9 @@ describe('errors', () => {
     expect(lexer.col).toBe(9)
     expect(lexer.formatError(undefined, "EOF!")).toBe(
       "EOF! at line 2 col 9:\n\n" +
-      "  def quxx\n" +
-      "          ^"
+      "     1\tabc\n" +
+      "     2\tdef quxx\n" +
+      "      \t        ^\n"
     )
   })
 
@@ -954,8 +960,9 @@ describe('errors', () => {
     expect(lexer.col).toBe(1)
     expect(lexer.formatError(undefined, "oh no!")).toBe(
       "oh no! at line 2 col 1:\n\n" +
-      "  def quxx\n" +
-      "  ^"
+      "     1\tabc\n" +
+      "     2\tdef quxx\n" +
+      "      \t^\n"
     )
   })
 


### PR DESCRIPTION
This PR adds a graphical representation of the last few lines before and error and highlighting of the error token from underneath, intended to make it easier to understand which part of the print out was cause of the error.