### PR TITLE
Avoid fall through in keywordTransform

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -364,6 +364,7 @@
         var tokenType = reverseMap[keyword]
         source += 'case ' + str(keyword) + ': return ' + str(tokenType) + '\n'
       })
+      source += 'default: return\n'
       source += '}\n'
     }
     source += '}\n'


### PR DESCRIPTION
The function generated by keywordTransform provides does not include switch defaults so a non-keyword that is of the same length as a keyword will be checked against all possible keyword values longer than it.

With the existing output a non keyword like 'x' is checked against both `case "a"` and `case "bb"`:
```js
//> console.log(moo.keywords({KW: ['a', 'bb'] }).toString())
function anonymous(value
) {
switch (value.length) {
case 1:
switch (value) {
case "a": return "KW"
}
case 2:
switch (value) {
case "bb": return "KW"
}
}

}
```

With the changes in this commit it is only checked against `case "a"`.
```js
//> console.log(moo.keywords({KW: ['a', 'bb'] }).toString())
function anonymous(value
) {
switch (value.length) {
case 1:
switch (value) {
case "a": return "KW"
default: return
}
case 2:
switch (value) {
case "bb": return "KW"
default: return
}
}

}
```
