### PR TITLE
Fix a bug, `queuedText` is not handled in `reset`

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -387,6 +387,7 @@
     this.line = info ? info.line : 1
     this.col = info ? info.col : 1
     this.queuedToken = info ? info.queuedToken : null
+    this.queuedText = info ? info.queuedText: "";
     this.queuedThrow = info ? info.queuedThrow : null
     this.setState(info ? info.state : this.startState)
     this.stack = info && info.stack ? info.stack.slice() : []
@@ -400,6 +401,7 @@
       state: this.state,
       stack: this.stack.slice(),
       queuedToken: this.queuedToken,
+      queuedText: this.queuedText,
       queuedThrow: this.queuedThrow,
     }
   }


### PR DESCRIPTION
In my project when using Nearley.js and moo.js together, after multiple times of parsing, sometimes the parser would throw an error.
I find that is due to moo.js, when it resets, the `queuedText` is not handled.
I think when it comes to reset and save, `queuedText` should be no different than `queuedToken` .
