### PR TITLE
Use a Map instead of compiled switch-case for keywords

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -335,7 +335,28 @@
   }
 
   function keywordTransform(map) {
-    var reverseMap = new Map
+
+    // Use a JavaScript Map to map keywords to their corresponding token type
+    // unless Map is unsupported, then fall back to using an Object:
+    var reverseMap, reverseMapGet, reverseMapSet;
+    try {
+      reverseMap = new Map
+      reverseMapGet = function(k) {
+        return reverseMap.get(k)
+      }
+      reverseMapSet = function (k, v) {
+        reverseMap.set(k, v)
+      }
+    } catch (_error) {
+      reverseMap = Object.create(null)
+      reverseMapGet = function(k) {
+        return reverseMap[k]
+      }
+      reverseMapSet = function (k, v) {
+        reverseMap[k] = v
+      }
+    }
+
     var types = Object.getOwnPropertyNames(map)
     for (var i = 0; i < types.length; i++) {
       var tokenType = types[i]
@@ -345,11 +366,11 @@
         if (typeof keyword !== 'string') {
           throw new Error("keyword must be string (in keyword '" + tokenType + "')")
         }
-        reverseMap.set(keyword, tokenType)
+        reverseMapSet(keyword, tokenType)
       })
     }
     return function(k) {
-      return reverseMap.get(k)  // type
+      return reverseMapGet(k)
     }
   }
 

--- a/moo.js
+++ b/moo.js
@@ -338,24 +338,8 @@
 
     // Use a JavaScript Map to map keywords to their corresponding token type
     // unless Map is unsupported, then fall back to using an Object:
-    var reverseMap, reverseMapGet, reverseMapSet;
-    try {
-      reverseMap = new Map
-      reverseMapGet = function(k) {
-        return reverseMap.get(k)
-      }
-      reverseMapSet = function (k, v) {
-        reverseMap.set(k, v)
-      }
-    } catch (_error) {
-      reverseMap = Object.create(null)
-      reverseMapGet = function(k) {
-        return reverseMap[k]
-      }
-      reverseMapSet = function (k, v) {
-        reverseMap[k] = v
-      }
-    }
+    var isMap = typeof Map !== 'undefined'
+    var reverseMap = isMap ? new Map : Object.create(null)
 
     var types = Object.getOwnPropertyNames(map)
     for (var i = 0; i < types.length; i++) {
@@ -366,11 +350,11 @@
         if (typeof keyword !== 'string') {
           throw new Error("keyword must be string (in keyword '" + tokenType + "')")
         }
-        reverseMapSet(keyword, tokenType)
+        isMap ? reverseMap.set(keyword, tokenType) : reverseMap[keyword] = tokenType
       })
     }
     return function(k) {
-      return reverseMapGet(k)
+      return isMap ? reverseMap.get(k) : reverseMap[k]
     }
   }
 

--- a/moo.js
+++ b/moo.js
@@ -335,40 +335,22 @@
   }
 
   function keywordTransform(map) {
-    var reverseMap = Object.create(null)
-    var byLength = Object.create(null)
+    var reverseMap = new Map
     var types = Object.getOwnPropertyNames(map)
     for (var i = 0; i < types.length; i++) {
       var tokenType = types[i]
       var item = map[tokenType]
       var keywordList = Array.isArray(item) ? item : [item]
       keywordList.forEach(function(keyword) {
-        (byLength[keyword.length] = byLength[keyword.length] || []).push(keyword)
         if (typeof keyword !== 'string') {
           throw new Error("keyword must be string (in keyword '" + tokenType + "')")
         }
-        reverseMap[keyword] = tokenType
+        reverseMap.set(keyword, tokenType)
       })
     }
-
-    // fast string lookup
-    // https://jsperf.com/string-lookups
-    function str(x) { return JSON.stringify(x) }
-    var source = ''
-    source += 'switch (value.length) {\n'
-    for (var length in byLength) {
-      var keywords = byLength[length]
-      source += 'case ' + length + ':\n'
-      source += 'switch (value) {\n'
-      keywords.forEach(function(keyword) {
-        var tokenType = reverseMap[keyword]
-        source += 'case ' + str(keyword) + ': return ' + str(tokenType) + '\n'
-      })
-      source += 'default: return\n'
-      source += '}\n'
+    return function(k) {
+      return reverseMap.get(k)  // type
     }
-    source += '}\n'
-    return Function('value', source) // type
   }
 
   /***************************************************************************/

--- a/moo.js
+++ b/moo.js
@@ -350,7 +350,11 @@
         if (typeof keyword !== 'string') {
           throw new Error("keyword must be string (in keyword '" + tokenType + "')")
         }
-        isMap ? reverseMap.set(keyword, tokenType) : reverseMap[keyword] = tokenType
+        if (isMap) {
+          reverseMap.set(keyword, tokenType)
+        } else {
+          reverseMap[keyword] = tokenType
+        }
       })
     }
     return function(k) {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -67,7 +67,7 @@ suite('keywords', () => {
   }
 
   const lexer = moo.compile({
-    name: {match: /[a-z]+/, keywords: {cowword: keywords}},
+    name: {match: /[a-z]+/, keywords: moo.keywords({cowword: keywords})},
     space: {match: /\s+/, lineBreaks: true},
   })
   lexer.reset(source)


### PR DESCRIPTION
As noted in #141, using `Function` causes issues for websites using a Content-Security-Policy that blocks `unsafe-eval` and it also appears that this is no longer the fastest approach.

This PR moves to using a Map, which [caniuse data suggests is supported](https://caniuse.com/mdn-javascript_builtins_map) in all major browsers released since 2015. I don't think the overhead of falling back to object attribute lookup is worthwhile unless you specifically support an ancient browser you know to be incompatible. I also altered the benchmark test to use `moo.keywords` since it was not doing so (although the difference to this benchmark is inside the noise when running in Node for me).

We're going to move to this Map approach in our project that uses `moo.js`, so we will have some real-world verification all works as expected in a few weeks if you want to wait for that.

Resolves #141.