### PR TITLE
Port CI to GitHub Actions

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [6.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install
+      - run: npm test
+      - run: npm run benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-    - "node"
-    - "6"
-install:
-    - npm install
-script:
-    - npm run test
-    - npm run benchmark


### PR DESCRIPTION
I noticed the travis CI config no longer works, and thought I'd make an MR with a similar GitHub actions build which should just work out of the box. It's pretty much just the node.js action template with the following changes:

- Node version: set to build on node.js 6.x (like the old travis build, presumably to test compatibility) and the current node.js LTS 16.x.

- `npm install` instead of `npm ci` in the template: `npm ci` is nicer, but doesn't work with node 6.x

- Run `npm run benchmark` in addition to `npm test`

Feel free to close though if you'd prefer to do it yourself or try to fix the travis CI.