### PR TITLE
Fix saving and resetting queued groups

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -409,9 +409,8 @@
     this.index = 0
     this.line = info ? info.line : 1
     this.col = info ? info.col : 1
-    this.queuedToken = info ? info.queuedToken : null
+    this.queuedGroup = info ? info.queuedGroup : null
     this.queuedText = info ? info.queuedText: "";
-    this.queuedThrow = info ? info.queuedThrow : null
     this.setState(info ? info.state : this.startState)
     this.stack = info && info.stack ? info.stack.slice() : []
     return this
@@ -423,9 +422,8 @@
       col: this.col,
       state: this.state,
       stack: this.stack.slice(),
-      queuedToken: this.queuedToken,
+      queuedGroup: this.queuedGroup,
       queuedText: this.queuedText,
-      queuedThrow: this.queuedThrow,
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -305,6 +305,33 @@ describe('fallback tokens', () => {
     expect(lexer.fast).toEqual({})
   })
 
+  test('save and reset', () => {
+    const lexer = compile({
+      number: {match: /\d+/},
+      text: moo.fallback
+    })
+    lexer.reset('test123')
+    lexer.next()
+
+    const savedInfo = lexer.save();
+    expect(savedInfo).toMatchObject({
+      queuedGroup: {defaultType: 'number'},
+      queuedText: '123'
+    })
+
+    lexer.reset()
+    expect(lexer).toMatchObject({
+      queuedGroup: null,
+      queuedText: '',
+    })
+
+    lexer.reset('', savedInfo)
+    expect(lexer.next()).toMatchObject({
+      type: 'number',
+      text: '123',
+    })
+  })
+
 })
 
 describe('keywords', () => {


### PR DESCRIPTION
Currently `Lexer.prototype.reset` and `Lexer.prototype.save` reference three `queued` fields: `queuedToken`, `queuedText` (added in #169) and `queuedThrow`. 

There only appear to be references to `queuedText` and `queuedGroup` elsewhere, so this MR removes `queuedToken` and 
`queuedThrow` and adds `queuedGroup` to `reset` and `save`.

The below example shows how this could be problematic - on master it prints a token when it probably shouldn't:
```
const moo = require("./moo")

const lexer = moo.compile({
    number: {match: /\d+/},
    text: moo.fallback
})

lexer.reset('test123')
lexer.next()
lexer.reset()
console.log(lexer.next())
```

