### PR TITLE
add `u`nicode flag where missing

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -22,7 +22,7 @@
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
   }
   function reGroups(s) {
-    var re = new RegExp('|' + s)
+    var re = new RegExp('|' + s,'u')
     return re.exec('').length - 1
   }
   function reCapture(s) {
@@ -260,7 +260,7 @@
       var pat = reUnion(match.map(regexpOrLiteral))
 
       // validate
-      var regexp = new RegExp(pat)
+      var regexp = new RegExp(pat,'u')
       if (regexp.test("")) {
         throw new Error("RegExp matches empty string: " + regexp)
       }


### PR DESCRIPTION
I realized that the below regex will be rejected with `Invalid regular expression: [...] Range out of order in character class` when using it in `moo.compile()` (Note: using extended syntax with extra whitespace for readability):

```coffee
/// [        A-Z _ a-z \u{00a1}-\u{10ffff}  ] [  $ 0-9 A-Z _ a-z \u{00a1}-\u{10ffff}  ]* ///u
```

This can be fixed by using the `u` flag on lines 25 and 263. Of course, this is something of a hotfix because that would presumably turn all regexes into Unicode regexes (maybe a Good Thing?); therefore, I leave it to those with better acquaintance with the codebase to come up with a proper solution.