### PR TITLE
Fix hyphens in Unicode mode

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -19,7 +19,10 @@
   function isObject(o) { return o && typeof o === 'object' && !isRegExp(o) && !Array.isArray(o) }
 
   function reEscape(s) {
-    return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+    return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, function(x) {
+      if (x === '-') return '\\x2d'
+      return '\\' + x
+    })
   }
   function reGroups(s) {
     var re = new RegExp('|' + s)

--- a/test/test.js
+++ b/test/test.js
@@ -1242,6 +1242,20 @@ describe('unicode flag', () => {
     ).not.toThrow()
   })
 
+  test("string literals work with /u rules", () => {
+    const lexer = compile({
+      OP: ['+=', '-='],
+      NUMBER: /[0-9]+/u,
+      WS: / +/u,
+    })
+    lexer.reset('3 -= 2')
+    expect(lexer.next()).toMatchObject({type: 'NUMBER', value: '3'})
+    expect(lexer.next()).toMatchObject({type: 'WS'})
+    expect(lexer.next()).toMatchObject({type: 'OP', value: '-='})
+    expect(lexer.next()).toMatchObject({type: 'WS'})
+    expect(lexer.next()).toMatchObject({type: 'NUMBER', value: '2'})
+  })
+
   test("supports unicode", () => {
     const lexer = compile({
       a: /[𝌆]/u,


### PR DESCRIPTION
String literals containing a hyphen `-` don’t work in combination with Unicode-mode regexes `/u` because `\-` is invalid outside a character class in Unicode mode.

This PR escapes hyphens as `\x2d` which works everywhere.

Fixes #144.